### PR TITLE
fix(make-buildable): new syntax for x-prompt of libType

### DIFF
--- a/packages/make-buildable/src/schematics/make-buildable/schema.json
+++ b/packages/make-buildable/src/schematics/make-buildable/schema.json
@@ -14,10 +14,28 @@
             "x-prompt": "What project would you like to migrate"
         },
         "libType": {
+            "type": "string",
             "enum": ["node", "nest", "angular"],
             "description": "Specify the type of library",
             "default": "node",
-            "x-prompt": "What kind of library is this?"
+            "x-prompt": {
+                "message": "What kind of library is this?",
+                "type": "list",
+                "items": [
+                    {
+                        "value": "node",
+                        "label": "Node"
+                    },
+                    {
+                        "value": "nest",
+                        "label": "Nest"
+                    },
+                    {
+                        "value": "angular",
+                        "label": "Angular"
+                    }
+                ]
+            }
         },
         "configs": {
             "type": "string",


### PR DESCRIPTION
enum with x-prompt wasn't working anymore with the new nx cli, need to be more explicit