### PR TITLE
Support libraries with dashes `-` in their names

### DIFF
--- a/packages/make-buildable/src/schematics/make-buildable/schematic.ts
+++ b/packages/make-buildable/src/schematics/make-buildable/schematic.ts
@@ -115,7 +115,7 @@ function normalizeOptions(
             .trim()
             .split(',')
             .map((config) => config.trim().toLowerCase()),
-        pathInLibs: options.projectName.replace(/-/g, '/'),
+        pathInLibs: project.root.substring(project.root.indexOf('/') + 1),
         angularVersion: versions.angular,
         tsLibVersion: versions.tsLib,
         npmScope,


### PR DESCRIPTION
Library names with dashes get converted into slashes, which will cause the destination path and package.json name to be incorrect. For example, a library created like this: `nx g library shared/test-library` would result in a module name and destination of `shared/test/library`, which fails to build.

I'm not sure if what's in the PR is the right way to address the problem, but it does work in our workspace. If there's an Nx folder structure that allows libraries to be stored at the root, then I imagine this would fail.