### PR TITLE
fix(make-buildable): schematics dont allow 'id' as field anymore

### DIFF
--- a/packages/make-buildable/src/schematics/make-buildable/schema.json
+++ b/packages/make-buildable/src/schematics/make-buildable/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "MakeBuildable",
+    "$id": "MakeBuildable",
     "title": "",
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Proposed Changes
`yarn nx g @trellisorg/make-buildable:migrate` is currently throwing this error. Must of been a change in one of the angular dev kit upgrades.

```
$ if [ -z $CI ]; then NG_PERSISTENT_BUILD_CACHE=1; fi && node --max_old_space_size=4096 ./node_modules/.bin/nx g ./dist/packages/make-buildable:migrate shared-type
✔ What kind of library is this? · node
✔ If this is an Angular lib, what configurations would you like to create? (separated by a comma) · 
Error: NOT SUPPORTED: keyword "id", use "$id" for schema ID
    at Object.code (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/vocabularies/core/id.js:6:15)
    at keywordCode (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/validate/index.js:454:13)
    at /home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/validate/index.js:222:17
    at CodeGen.code (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/codegen/index.js:439:13)
    at CodeGen.block (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/codegen/index.js:568:18)
    at iterateKeywords (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/validate/index.js:219:9)
    at groupKeywords (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/validate/index.js:208:13)
    at /home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/validate/index.js:192:13
    at CodeGen.code (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/codegen/index.js:439:13)
    at CodeGen.block (/home/jordan-wsl2/platform/node_modules/@angular-devkit/core/node_modules/ajv/dist/compile/codegen/index.js:568:18)
NOT SUPPORTED: keyword "id", use "$id" for schema ID
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)


