### PR TITLE
fix: remove bullet reference from package docs

### DIFF
--- a/packages/graphql-codegen-make-export-as-optional/README.md
+++ b/packages/graphql-codegen-make-export-as-optional/README.md
@@ -58,7 +58,6 @@ generates:
             querySuffix: 'QueryService'
             mutationSuffix: 'MutationService'
             subscriptionSuffix: 'SubscriptionService'
-            namedClient: 'bullet'
             addExplicitOverride: true
         plugins:
             - 'typescript-apollo-angular'

--- a/packages/graphql-codegen-make-export-as-optional/package.json
+++ b/packages/graphql-codegen-make-export-as-optional/package.json
@@ -6,7 +6,7 @@
         "directory": "packages/graphql-codegen-make-export-as-optional"
     },
     "readme": "https://github.com/trellisorg/platform/tree/master/packages/graphql-codegen-make-export-as-optional",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "main": "src/index.js",
     "dependencies": {

--- a/packages/graphql-codegen-restore-export-as-changes/package.json
+++ b/packages/graphql-codegen-restore-export-as-changes/package.json
@@ -6,7 +6,7 @@
         "directory": "packages/graphql-codegen-restore-export-as-changes"
     },
     "readme": "https://github.com/trellisorg/platform/tree/master/packages/graphql-codegen-restore-export-as-changes",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "main": "src/index.js",
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3720,14 +3720,7 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash.set@^4.3.7":
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.7.tgz#784fccea3fbef4d0949d1897a780f592da700942"
-  integrity sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*", "@types/lodash@^4.14.191":
+"@types/lodash@^4.14.191":
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
@@ -9184,11 +9177,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
A namedClient of bullet slipped into the documentation, might as well remove that.

Also yarn.lock was out of date.